### PR TITLE
Keep logger metadata in the processes spawned by TeleTask

### DIFF
--- a/lib/prima_opentelemetry_ex/teletask.ex
+++ b/lib/prima_opentelemetry_ex/teletask.ex
@@ -9,9 +9,11 @@ defmodule PrimaOpentelemetryEx.TeleTask do
   @spec start((() -> any())) :: {:ok, pid()}
   def start(fun) do
     ctx = Tracer.current_span_ctx()
+    meta = Logger.metadata()
 
     Task.start(fn ->
       Tracer.set_current_span(ctx)
+      Logger.metadata(meta)
       fun.()
     end)
   end
@@ -19,9 +21,11 @@ defmodule PrimaOpentelemetryEx.TeleTask do
   @spec async((() -> any)) :: Task.t()
   def async(fun) do
     ctx = Tracer.current_span_ctx()
+    meta = Logger.metadata()
 
     Task.async(fn ->
       Tracer.set_current_span(ctx)
+      Logger.metadata(meta)
       fun.()
     end)
   end


### PR DESCRIPTION
We're doing something similar in Stonehenge, would be nice if we could get rid of that helper and use TeleTask.

https://github.com/primait/stonehenge/blob/master/apps/metrix/lib/metrix/helpers/task_helper.ex