### PR TITLE
Fix OTLP exporter not starting in Distillery/Mix releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+### Changed
+
+- `PrimaOpentelemetryEx.setup()` will raise an error if `opentelemetry` or `opentelemetry_exporter` applications fail to start for some reason
+
+### Fixed
+
+- Fix OTLP exporter not starting in Distillery/Mix releases, due to `opentelemetry` and `opentelemetry_exporter` not being included in the release
+
 ## [1.1.1] - 2022-09-07
 
 ### Fixed

--- a/lib/prima_opentelemetry_ex.ex
+++ b/lib/prima_opentelemetry_ex.ex
@@ -18,8 +18,8 @@ defmodule PrimaOpentelemetryEx do
       set_processor()
       instrument()
 
-      Application.ensure_all_started(:opentelemetry_exporter)
-      Application.ensure_all_started(:opentelemetry)
+      {:ok, _} = Application.ensure_all_started(:opentelemetry_exporter)
+      {:ok, _} = Application.ensure_all_started(:opentelemetry)
     end
 
     :ok

--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,8 @@ defmodule PrimaOpentelemetryEx.MixProject do
   def application do
     [
       extra_applications: [:logger],
+      # We need to add these as included_applications because otherwise they won't be included
+      # in Distillery/Mix releases, since we declared them as `runtime: false`
       included_applications: [:opentelemetry, :opentelemetry_exporter]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule PrimaOpentelemetryEx.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      included_applications: [:opentelemetry, :opentelemetry_exporter]
     ]
   end
 


### PR DESCRIPTION
`included_applications` was required in order to include opentelemetry and opentelemetry_exporter dependencies (which have `runtime: false`) in release packages.