### PR TITLE
Fix a compile warning

### DIFF
--- a/lib/prima_opentelemetry_ex/instrumentation/opentelemetry_ecto.ex
+++ b/lib/prima_opentelemetry_ex/instrumentation/opentelemetry_ecto.ex
@@ -11,11 +11,11 @@ defmodule PrimaOpentelemetryEx.Instrumentation.OpentelemetryEcto do
       "repo-init-handler",
       [:ecto, :repo, :init],
       fn _event, _measurements, metadata, _config ->
-    	metadata
-    	|> Map.fetch!(:opts)
-    	|> Keyword.fetch!(:telemetry_prefix)
-    	|> OpentelemetryEcto.setup()
-  	end,
+        metadata
+        |> Map.fetch!(:opts)
+        |> Keyword.fetch!(:telemetry_prefix)
+        |> OpentelemetryEcto.setup()
+      end,
       %{}
     )
   end

--- a/lib/prima_opentelemetry_ex/instrumentation/opentelemetry_ecto.ex
+++ b/lib/prima_opentelemetry_ex/instrumentation/opentelemetry_ecto.ex
@@ -10,15 +10,13 @@ defmodule PrimaOpentelemetryEx.Instrumentation.OpentelemetryEcto do
     :telemetry.attach(
       "repo-init-handler",
       [:ecto, :repo, :init],
-      &__MODULE__.instrument_repo/4,
+      fn _event, _measurements, metadata, _config ->
+    	metadata
+    	|> Map.fetch!(:opts)
+    	|> Keyword.fetch!(:telemetry_prefix)
+    	|> OpentelemetryEcto.setup()
+  	end,
       %{}
     )
-  end
-
-  def instrument_repo(_event, _measurements, metadata, _config) do
-    metadata
-    |> Map.fetch!(:opts)
-    |> Keyword.fetch!(:telemetry_prefix)
-    |> OpentelemetryEcto.setup()
   end
 end


### PR DESCRIPTION
```
warning: OpentelemetryEcto.setup/1 is undefined (module OpentelemetryEcto is not available or is yet to be defined)
  lib/prima_opentelemetry_ex/instrumentation/opentelemetry_ecto.ex:22: PrimaOpentelemetryEx.Instrumentation.OpentelemetryEcto.instrument_repo/4
```