### PR TITLE
[PMPDD-72]: Fix warning on attaching an anonymous function to telemetry

### DIFF
--- a/lib/prima_opentelemetry_ex/instrumentation/opentelemetry_ecto.ex
+++ b/lib/prima_opentelemetry_ex/instrumentation/opentelemetry_ecto.ex
@@ -4,18 +4,20 @@ defmodule PrimaOpentelemetryEx.Instrumentation.OpentelemetryEcto do
   alias PrimaOpentelemetryEx.Instrumentation.Optional
   require Optional
 
+  def repo_init_handler(_event, _measurements, metadata, _config) do
+    metadata
+    |> Map.fetch!(:opts)
+    |> Keyword.fetch!(:telemetry_prefix)
+    |> OpentelemetryEcto.setup()
+  end
+
   Optional.instrument Ecto,
     with: OpentelemetryEcto,
     feature: :ecto do
     :telemetry.attach(
       "repo-init-handler",
       [:ecto, :repo, :init],
-      fn _event, _measurements, metadata, _config ->
-        metadata
-        |> Map.fetch!(:opts)
-        |> Keyword.fetch!(:telemetry_prefix)
-        |> OpentelemetryEcto.setup()
-      end,
+      &__MODULE__.repo_init_handler/4,
       %{}
     )
   end


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PMPDD-72

While I was upgrading dependencies on `scrivania`, I noticed the following warning

```
[info] The function passed as a handler with ID "repo-init-handler" is a local function.
This means that it is either an anonymous function or a capture of a function without a module specified. That may cause a performance penalty when calling that handler. For more details see the note in `telemetry:attach/4` documentation.

https://hexdocs.pm/telemetry/telemetry.html#attach/4
```

not a big problem, but I thought it would be nice to remove it from future versions.
