### PR TITLE
allow teleplug ~> 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.1.2] - 2024-12-12
+
+- Teleplug can now be ~> 2.0
+
+---
+
 ## [2.1.1] - 2024-06-17
 
 ### Fixed

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule PrimaOpentelemetryEx.MixProject do
     [
       {:opentelemetry_absinthe, "~> 2.0", optional: true},
       {:opentelemetry_ecto, "~> 1.0", optional: true},
-      {:teleplug, "~> 1.1", optional: true}
+      {:teleplug, "~> 1.1 or ~> 2.0", optional: true}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PrimaOpentelemetryEx.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/primait/prima_opentelemetry_ex"
-  @version "2.1.1"
+  @version "2.1.2"
 
   def project do
     [


### PR DESCRIPTION
So that projects depending on prima_opentelemetry_ex can depend on https://github.com/primait/teleplug/releases/tag/2.0.0